### PR TITLE
feat: support multiple configuration file paths

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,25 @@ json:
 
 設定ファイルを `$XDG_CONFIG_HOME/any-script-mcp/config.yaml` に作成します（通常は `~/.config/any-script-mcp/config.yaml`）。
 
+`ANY_SCRIPT_MCP_CONFIG` 環境変数を使用してカスタム設定ファイルのパスを指定することもできます：
+
+```shell-session
+# 単一の設定ファイル
+$ ANY_SCRIPT_MCP_CONFIG=/path/to/custom/config.yaml npx any-script-mcp
+
+# 複数の設定ファイル（Unix/macOS - コロンで区切る）
+$ ANY_SCRIPT_MCP_CONFIG=/path/to/custom.yaml:$XDG_CONFIG_HOME/any-script-mcp/config.yaml npx any-script-mcp
+
+# 複数の設定ファイル（Windows - セミコロンで区切る）
+$ ANY_SCRIPT_MCP_CONFIG=C:\path\to\custom.yaml;%APPDATA%\any-script-mcp\config.yaml npx any-script-mcp
+```
+
+複数の設定ファイルを指定した場合：
+- すべてのファイルのツールが1つのコレクションにマージされます
+- 同じツール名が複数のファイルに存在する場合、最初に出現したものが優先されます
+- 少なくとも1つの有効な設定ファイルが正常に読み込まれる必要があります
+- 共通ツールとプロジェクト固有またはパーソナルカスタマイゼーションを分離するのに便利です
+
 ### 設定のテスト
 
 MCP Inspectorを使って設定をテストできます：

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ json:
 
 Create a configuration file at `$XDG_CONFIG_HOME/any-script-mcp/config.yaml` (typically `~/.config/any-script-mcp/config.yaml`).
 
+You can also specify custom configuration file paths using the `ANY_SCRIPT_MCP_CONFIG` environment variable:
+
+```shell-session
+# Single configuration file
+$ ANY_SCRIPT_MCP_CONFIG=/path/to/custom/config.yaml npx any-script-mcp
+
+# Multiple configuration files (Unix/macOS - separated by colon)
+$ ANY_SCRIPT_MCP_CONFIG=/path/to/custom.yaml:$XDG_CONFIG_HOME/any-script-mcp/config.yaml npx any-script-mcp
+
+# Multiple configuration files (Windows - separated by semicolon)
+$ ANY_SCRIPT_MCP_CONFIG=C:\path\to\custom.yaml;%APPDATA%\any-script-mcp\config.yaml npx any-script-mcp
+```
+
+When multiple configuration files are specified:
+- All tools from all files are merged into a single collection
+- If the same tool name appears in multiple files, the first occurrence takes precedence
+- At least one valid configuration file must be successfully loaded
+- This is useful for separating common tools from project-specific or personal customizations
+
 ### Testing Your Configuration
 
 You can test your configuration using the MCP Inspector:

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,7 @@ import { z } from "zod";
 import { type ConfigError, loadConfig, type ToolConfig } from "./config.js";
 import { executeCommand } from "./executor.js";
 
-function printConfigError(error: ConfigError): void {
-  console.error("Configuration Error:\n");
-
+function printConfigErrorDetails(error: ConfigError): void {
   switch (error.type) {
     case "LOAD_ERROR":
       console.error(`Failed to load config from: ${error.path}`);
@@ -17,14 +15,26 @@ function printConfigError(error: ConfigError): void {
 
     case "VALIDATION_ERROR":
       console.error(`Invalid configuration in: ${error.path}`);
-      console.error("\nValidation errors:");
+      console.error("Validation errors:");
       error.issues.forEach((issue) => {
         const path = issue.path.length > 0 ? issue.path.join(".") : "root";
-        console.error(`  - ${path}: ${issue.message}`);
+        console.error(`- ${path}: ${issue.message}`);
+      });
+      break;
+
+    case "MULTIPLE_ERRORS":
+      console.error("Failed to load configuration from multiple files:");
+      error.errors.forEach(({ error: fileError }) => {
+        console.error("");
+        printConfigErrorDetails(fileError);
       });
       break;
   }
+}
 
+function printConfigError(error: ConfigError): void {
+  console.error("Configuration Error:\n");
+  printConfigErrorDetails(error);
   console.error(
     "\nSee documentation at: https://github.com/izumin5210/any-script-mcp",
   );


### PR DESCRIPTION
## Summary
- Added support for specifying multiple configuration file paths via `ANY_SCRIPT_MCP_CONFIG` environment variable
- Configuration files can be separated using platform-specific delimiters (`:` on Unix/macOS, `;` on Windows)
- Tool definitions from all valid config files are merged into a single collection

## Features
- **Multiple config paths**: Users can now specify multiple YAML configuration files
- **Platform-aware delimiters**: Uses `:` for Unix/macOS and `;` for Windows
- **Tool precedence**: When the same tool name appears in multiple files, the first occurrence takes precedence
- **Partial loading**: The server will start successfully if at least one config file loads without errors
- **Enhanced error reporting**: Added `MULTIPLE_ERRORS` type to report issues from multiple config files

## Use Cases
- Separate common tools from project-specific customizations
- Layer personal tools on top of team/organization defaults
- Override default tools with custom implementations

## Example
```bash
# Unix/macOS
ANY_SCRIPT_MCP_CONFIG=/path/to/custom.yaml:$XDG_CONFIG_HOME/any-script-mcp/config.yaml npx any-script-mcp

# Windows
ANY_SCRIPT_MCP_CONFIG=C:\path\to\custom.yaml;%APPDATA%\any-script-mcp\config.yaml npx any-script-mcp
```

## Test Plan
- [x] Added comprehensive test cases for multiple config paths
- [x] Tested tool name conflict resolution
- [x] Tested partial loading when some configs fail
- [x] Tested empty path segment handling
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)