### PR TITLE
feat: add JSON Schema generation for configuration file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             run: pnpm build
           - name: test
             run: pnpm test
+          - name: gen:schema
+            run: pnpm gen:schema
       fail-fast: false
 
     name: ${{ matrix.commands.name }}
@@ -36,7 +38,7 @@ jobs:
           aqua_version: v2.43.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22'
           cache: 'pnpm'
       - run: pnpm install
       - name: Run `${{ matrix.commands.run }}`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This will open a web interface where you can see your registered tools and test 
 ### Example Configuration
 
 ```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/izumin5210/any-script-mcp/main/config.schema.json
 tools:
   - name: echo
     description: Echo a message

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/izumin5210/any-script-mcp/main/config.schema.json",
+  "title": "Any Script MCP Configuration",
+  "description": "Configuration schema for any-script-mcp - MCP server that exposes arbitrary CLI tools and shell scripts as MCP Tools via YAML configuration",
+  "$ref": "#/definitions/AnyScriptMCPConfig",
+  "definitions": {
+    "AnyScriptMCPConfig": {
+      "type": "object",
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_-]+$"
+              },
+              "description": {
+                "type": "string"
+              },
+              "inputs": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["string", "number", "boolean"]
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "default": {}
+                  },
+                  "required": ["type", "description"],
+                  "additionalProperties": false
+                },
+                "propertyNames": {
+                  "pattern": "^[a-zA-Z0-9_-]+$"
+                },
+                "default": {}
+              },
+              "run": {
+                "type": "string"
+              },
+              "timeout": {
+                "type": "number",
+                "default": 300000
+              }
+            },
+            "required": ["name", "description", "run"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["tools"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "build": "tsc && chmod +x ./out/index.js",
     "check": "biome check --write",
+    "gen:schema": "node --experimental-strip-types scripts/generate-schema.ts",
     "test": "vitest",
     "test:run": "vitest run",
     "test:watch": "vitest --watch"
@@ -38,7 +39,8 @@
     "@biomejs/biome": "2.1.4",
     "@types/node": "22.17.1",
     "typescript": "5.9.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "zod-to-json-schema": "^3.24.6"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,10 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.17.1)(yaml@2.8.1)
+        version: 3.2.4(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1)
+      zod-to-json-schema:
+        specifier: ^3.24.6
+        version: 3.24.6(zod@3.25.76)
 
 packages:
 
@@ -600,6 +603,9 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -778,6 +784,9 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.46.2:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -885,6 +894,11 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -1238,13 +1252,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.1(@types/node@22.17.1)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.1(@types/node@22.17.1)(yaml@2.8.1)
+      vite: 7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1524,6 +1538,11 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    optional: true
+
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -1654,6 +1673,9 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       unpipe: 1.0.0
+
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   rollup@4.46.2:
     dependencies:
@@ -1793,6 +1815,14 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.8
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -1813,13 +1843,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.17.1)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.1(@types/node@22.17.1)(yaml@2.8.1)
+      vite: 7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1834,7 +1864,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.1(@types/node@22.17.1)(yaml@2.8.1):
+  vite@7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -1845,13 +1875,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.17.1
       fsevents: 2.3.3
+      tsx: 4.20.5
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@22.17.1)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.1(@types/node@22.17.1)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1869,8 +1900,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.1(@types/node@22.17.1)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@22.17.1)(yaml@2.8.1)
+      vite: 7.1.1(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.17.1)(tsx@4.20.5)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.1

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,0 +1,29 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { ConfigSchema } from "../src/config.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Generate JSON Schema
+const jsonSchema = zodToJsonSchema(ConfigSchema, {
+  name: "AnyScriptMCPConfig",
+  $refStrategy: "none",
+});
+
+// Add additional metadata
+const schemaWithMetadata = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://raw.githubusercontent.com/izumin5210/any-script-mcp/main/config.schema.json",
+  title: "Any Script MCP Configuration",
+  description:
+    "Configuration schema for any-script-mcp - MCP server that exposes arbitrary CLI tools and shell scripts as MCP Tools via YAML configuration",
+  ...jsonSchema,
+};
+
+// Write to file
+const outputPath = `${__dirname}/../config.schema.json`;
+await writeFile(outputPath, JSON.stringify(schemaWithMetadata, null, 2) + "\n");
+
+console.log(`✅ Schema generated at: config.schema.json`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,14 +8,14 @@ import { z } from "zod";
 // Input name constraint (alphanumeric, underscore, and hyphen only)
 const INPUT_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 
-const ToolInputSchema = z.object({
+export const ToolInputSchema = z.object({
   type: z.enum(["string", "number", "boolean"]),
   description: z.string(),
   required: z.boolean().optional().default(true),
   default: z.any().optional(),
 });
 
-const ToolConfigSchema = z.object({
+export const ToolConfigSchema = z.object({
   name: z.string().regex(/^[a-zA-Z0-9_-]+$/),
   description: z.string(),
   inputs: z
@@ -31,7 +31,7 @@ const ToolConfigSchema = z.object({
   timeout: z.number().optional().default(300_000), // 5 minutes in milliseconds
 });
 
-const ConfigSchema = z.object({
+export const ConfigSchema = z.object({
   tools: z.array(ToolConfigSchema),
 });
 


### PR DESCRIPTION
## Summary
- Add automatic JSON Schema generation from Zod schemas
- Enable autocompletion and validation in editors like VSCode
- Ensure schema is always up-to-date through CI checks

## Changes
- `scripts/generate-schema.ts`: Add script to generate JSON Schema from Zod schemas
- `src/config.ts`: Export schemas for reusability
- `config.schema.json`: Generated JSON Schema file (placed at repository root)
- `README.md`: Add yaml-language-server directive to configuration examples
- `.github/workflows/ci.yml`: Add schema sync check to matrix, update to Node.js 22

## Test plan
- [ ] Run `pnpm gen:schema` and verify schema generation works
- [ ] Verify generated schema is valid JSON Schema
- [ ] Confirm CI diff check works after running `pnpm gen:schema`

🤖 Generated with [Claude Code](https://claude.ai/code)