### PR TITLE
feat: add INPUTS_JSON environment variable for type preservation

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -24,6 +24,9 @@ export async function executeCommand(
       env[envKey] = String(value);
     }
 
+    // Also provide inputs as JSON to preserve type information
+    env["INPUTS_JSON"] = JSON.stringify(inputs);
+
     // Replace all {0} placeholders with the script file path
     const command = config.shell.replaceAll("{0}", tmpFile);
 


### PR DESCRIPTION
## Summary
- Add `INPUTS_JSON` environment variable that passes all inputs as a single JSON object
- Preserve type information (numbers stay as numbers, booleans as booleans) for non-shell interpreters
- Maintain full backward compatibility with existing `INPUTS__` prefixed environment variables

## Motivation
When using non-shell interpreters (Node.js, Python, Deno), all environment variables are strings, requiring manual type conversion. This adds complexity and potential bugs. The new `INPUTS_JSON` environment variable solves this by preserving the original types.

## Changes
- **executor.ts**: Added `INPUTS_JSON` environment variable alongside existing individual variables
- **Tests**: Added comprehensive unit tests and E2E tests
- **Documentation**: Updated README with usage examples and benefits

## Test plan
- [x] Unit tests for type preservation in executor.test.ts
- [x] E2E tests for MCP server integration in server.test.ts
- [x] Tests pass for Node.js, Python examples
- [x] Backward compatibility verified

🤖 Generated with [Claude Code](https://claude.ai/code)